### PR TITLE
Add setters and support for all Print.h operations

### DIFF
--- a/src/MqttLogger.cpp
+++ b/src/MqttLogger.cpp
@@ -1,15 +1,37 @@
 #include "MqttLogger.h"
 #include "Arduino.h"
 
-MqttLogger::MqttLogger(PubSubClient& client, const char* topic, MqttLoggerMode mode)
+MqttLogger::MqttLogger(MqttLoggerMode mode)
 {
-    this->client = &client;
-    this->topic = topic;
-    this->mode = mode;
+    this->setMode(mode);
     this->setBufferSize(MQTT_MAX_PACKET_SIZE);
 }
+
+MqttLogger::MqttLogger(PubSubClient& client, const char* topic, MqttLoggerMode mode)
+{
+    this->setClient(client);
+    this->setTopic(topic);
+    this->setMode(mode);
+    this->setBufferSize(MQTT_MAX_PACKET_SIZE);
+}
+
 MqttLogger::~MqttLogger()
 {
+}
+
+void MqttLogger::setClient(PubSubClient& client)
+{
+    this->client = &client;
+}
+
+void MqttLogger::setTopic(const char* topic)
+{
+    this->topic = topic;
+}
+
+void MqttLogger::setMode(MqttLoggerMode mode)
+{
+    this->mode = mode;
 }
 
 uint16_t MqttLogger::getBufferSize()
@@ -51,8 +73,8 @@ void MqttLogger::sendBuffer()
 {
     if (this->bufferCnt > 0)
     {
-        bool doSerial = this->mode==MqttLoggerMode::SerialOnly || this->mode==MqttLoggerMode::MqttAndSerial; 
-        if (this->mode!=MqttLoggerMode::SerialOnly && this->client->connected()) 
+        bool doSerial = this->mode==MqttLoggerMode::SerialOnly || this->mode==MqttLoggerMode::MqttAndSerial;
+        if (this->mode!=MqttLoggerMode::SerialOnly && this->client != NULL && this->client->connected()) 
         {
             this->client->publish(this->topic, (byte *)this->buffer, this->bufferCnt, 1);
         } else if (this->mode == MqttLoggerMode::MqttAndSerialFallback)

--- a/src/MqttLogger.h
+++ b/src/MqttLogger.h
@@ -42,6 +42,8 @@ public:
     void setRetained(boolean retained);
     
     virtual size_t write(uint8_t);
+    using Print::write;
+    
     uint16_t getBufferSize();
     boolean setBufferSize(uint16_t size);
 };

--- a/src/MqttLogger.h
+++ b/src/MqttLogger.h
@@ -32,8 +32,15 @@ private:
     void sendBuffer();
 
 public:
-    MqttLogger(PubSubClient& client, const char* topic, MqttLoggerMode mode=MqttLoggerMode::MqttAndSerialFallback); // constructor & destructor
+    MqttLogger(MqttLoggerMode mode=MqttLoggerMode::MqttAndSerialFallback);
+    MqttLogger(PubSubClient& client, const char* topic, MqttLoggerMode mode=MqttLoggerMode::MqttAndSerialFallback);
     ~MqttLogger();
+
+    void setClient(PubSubClient& client);
+    void setTopic(const char* topic);
+    void setMode(MqttLoggerMode mode);
+    void setRetained(boolean retained);
+    
     virtual size_t write(uint8_t);
     uint16_t getBufferSize();
     boolean setBufferSize(uint16_t size);


### PR DESCRIPTION
This is a great piece of software - thank you for sharing!

I needed to use it in a library I am developing, and to make it nice and generic I need to be able to instantiate and use the logger before an MQTT connection is started. These changes allow me to create a logger and then set the MQTT client and topic at a later time. In the meantime any logging is sent to serial, as if the MQTT connection is down.

I also added the `using Print::write()` to ensure all `Print` operations are supported, e.g. `write(uint8_t *, uint16_t)`.